### PR TITLE
57 Mechanism to save console as one .exe file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,3 +397,6 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 backend/.idea/
+
+# .exe files of ConsoleApp
+ExecutableFiles/

--- a/CreateExeOfConsoleApp.cmd
+++ b/CreateExeOfConsoleApp.cmd
@@ -1,13 +1,23 @@
 
+:: Setting common parameters
 SET outputDir=.\ExecutableFiles
 SET exeFileName=Squirrel.ConsoleApp
 SET exeCustomFileNamePrefix=Squirrel
 SET pathToSln=.\backend\Squirrel.ConsoleApp.sln
 
+
+:: Script body
 del /s /q "%outputDir%"
 
-dotnet publish "%pathToSln%" -r win-x64 -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=true -p:EnableCompressionInSingleFile=true --output "%outputDir%"
-ren "%outputDir%\%exeFileName%.exe" "%exeCustomFileNamePrefix%-win-x64.exe"
+call :PublishApp win-x64
+call :PublishApp win-x86
 
-dotnet publish "%pathToSln%" -r win-x86 -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=true -p:EnableCompressionInSingleFile=true --output "%outputDir%"
-ren "%outputDir%\%exeFileName%.exe" "%exeCustomFileNamePrefix%-win-x86.exe"
+exit /b
+
+
+:: Subroutine description
+:PublishApp
+set architecture=%1
+
+dotnet publish "%pathToSln%" -r %architecture% -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=true -p:EnableCompressionInSingleFile=true --output "%outputDir%"
+ren "%outputDir%\%exeFileName%.exe" "%exeCustomFileNamePrefix%-%architecture%.exe"

--- a/CreateExeOfConsoleApp.cmd
+++ b/CreateExeOfConsoleApp.cmd
@@ -1,0 +1,13 @@
+
+SET outputDir=.\ExecutableFiles
+SET exeFileName=Squirrel.ConsoleApp
+SET exeCustomFileNamePrefix=Squirrel
+SET pathToSln=.\backend\Squirrel.ConsoleApp.sln
+
+del /s /q "%outputDir%"
+
+dotnet publish "%pathToSln%" -r win-x64 -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=true -p:EnableCompressionInSingleFile=true --output "%outputDir%"
+ren "%outputDir%\%exeFileName%.exe" "%exeCustomFileNamePrefix%-win-x64.exe"
+
+dotnet publish "%pathToSln%" -r win-x86 -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=true -p:EnableCompressionInSingleFile=true --output "%outputDir%"
+ren "%outputDir%\%exeFileName%.exe" "%exeCustomFileNamePrefix%-win-x86.exe"


### PR DESCRIPTION
- Added .cmd file at the root project folder;
- The script create two self-sufficient .exe files for x64 and x86 Windows architecture;
- Those files placed at the “ExecutableFiles“ folder at the project root.

![image](https://github.com/BinaryStudioAcademy/bsa-2023-squirrel/assets/107005256/f2e25284-c8cf-4777-a0a3-69f0803537d9)
![image](https://github.com/BinaryStudioAcademy/bsa-2023-squirrel/assets/107005256/ef883f35-dde9-4a44-b673-ef930c9b66a7)
