### PR TITLE
Delete "File Name" input field from modal window 

### DIFF
--- a/frontend/src/app/modules/scripts/create-script-modal/create-script-modal.component.html
+++ b/frontend/src/app/modules/scripts/create-script-modal/create-script-modal.component.html
@@ -2,20 +2,22 @@
     <h4 class="header">Create new script</h4>
     <mat-dialog-content>
         <div class="input-container">
-            <app-input placeholder="Enter the name of your script"
-                       [formControl]="$any(newScriptForm.controls['scriptName'])" label="Script name">
-            </app-input>
-            <app-input placeholder="Enter the file name" [formControl]="$any(newScriptForm.controls['fileName'])"
-                       label="File name">
+            <app-input
+                placeholder="Enter the name of your script"
+                [formControl]="$any(newScriptForm.controls['scriptName'])"
+                label="Script name">
             </app-input>
         </div>
     </mat-dialog-content>
 
     <mat-dialog-actions class="modal-buttons">
-        <app-button text="Create" width="100%" variant="outline-secondary" [isDisabled]="newScriptForm.invalid"
-                    (buttonOnClick)="createScript()">
+        <app-button
+            text="Create"
+            width="100%"
+            variant="outline-secondary"
+            [isDisabled]="newScriptForm.invalid"
+            (buttonOnClick)="createScript()">
         </app-button>
-        <app-button text="Close" width="100%" variant="outline-secondary" (mousedown)="close()">
-        </app-button>
+        <app-button text="Close" width="100%" variant="outline-secondary" (mousedown)="close()"></app-button>
     </mat-dialog-actions>
 </div>

--- a/frontend/src/app/modules/scripts/create-script-modal/create-script-modal.component.ts
+++ b/frontend/src/app/modules/scripts/create-script-modal/create-script-modal.component.ts
@@ -37,7 +37,7 @@ export class CreateScriptModalComponent extends BaseComponent implements OnInit 
     public initForm(): void {
         this.newScriptForm = this.formBuilder.group({
             scriptName: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(100)]],
-            fileName: ['', [Validators.required, Validators.minLength(2), Validators.maxLength(100)]],
+            // fileName: ['', [Validators.required, Validators.minLength(2), Validators.maxLength(100)]],
         });
     }
 
@@ -48,7 +48,7 @@ export class CreateScriptModalComponent extends BaseComponent implements OnInit 
             if (project) {
                 const newScriptDto: CreateScriptDto = {
                     title: this.newScriptForm.value.scriptName,
-                    fileName: this.newScriptForm.value.fileName,
+                    fileName: this.newScriptForm.value.scriptName,
                     projectId: project.id as number,
                 };
 

--- a/frontend/src/app/modules/scripts/create-script-modal/create-script-modal.component.ts
+++ b/frontend/src/app/modules/scripts/create-script-modal/create-script-modal.component.ts
@@ -37,7 +37,6 @@ export class CreateScriptModalComponent extends BaseComponent implements OnInit 
     public initForm(): void {
         this.newScriptForm = this.formBuilder.group({
             scriptName: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(100)]],
-            // fileName: ['', [Validators.required, Validators.minLength(2), Validators.maxLength(100)]],
         });
     }
 

--- a/frontend/src/app/modules/scripts/scripts-page/scripts-page.component.ts
+++ b/frontend/src/app/modules/scripts/scripts-page/scripts-page.component.ts
@@ -109,7 +109,7 @@ export class ScriptsPageComponent extends BaseComponent implements OnInit, CanCo
         const dialogRef: any = this.dialog.open(CreateScriptModalComponent, {
             panelClass: 'custom-dialog-container',
             width: '450px',
-            height: '370px',
+            height: '250px',
         });
 
         dialogRef.componentInstance.scriptCreated.subscribe((newScript: ScriptDto) => {

--- a/frontend/src/app/modules/scripts/scripts-page/scripts-page.component.ts
+++ b/frontend/src/app/modules/scripts/scripts-page/scripts-page.component.ts
@@ -109,7 +109,6 @@ export class ScriptsPageComponent extends BaseComponent implements OnInit, CanCo
         const dialogRef: any = this.dialog.open(CreateScriptModalComponent, {
             panelClass: 'custom-dialog-container',
             width: '450px',
-            height: '250px',
         });
 
         dialogRef.componentInstance.scriptCreated.subscribe((newScript: ScriptDto) => {


### PR DESCRIPTION
![image](https://github.com/BinaryStudioAcademy/bsa-2023-squirrel/assets/56000582/694129cd-c1de-435f-94c5-891cb8d04aa8)


- removed "FileName" input field from create-script-modal
* changed modal window size
* fileName in DTO takes the value of scriptName field